### PR TITLE
chore(docker): switch base image from node:slim to node:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
     make \
     g++ && \
     corepack enable && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    ln -sf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 # syntax=docker/dockerfile:1.4
 
-FROM node:20.18-slim AS base
+FROM node:20.18-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    libc6 \
+RUN apk add --no-cache \
     python3 \
     make \
     g++ && \


### PR DESCRIPTION
- Replace node:20.18-slim with node:20.18-alpine for a lighter image
- Update package installation commands from apt to apk
- Remove unnecessary libc6 dependency