### PR TITLE
ci(workflow): restrict version tagging to main branch merges

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,6 +2,7 @@ name: Backend Container
 on:
   push:
     branches: ["main"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,10 +23,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Ajout d'une condition pour la génération de tag
       - name: Generate version tag
         id: tag_version
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +39,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Ajout d'une condition pour le login
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3


### PR DESCRIPTION
- Add condition to only generate version tags on main branch merges
- Skip version increment during pull requests
- Ensure semantic versioning only happens after successful merges